### PR TITLE
fix travis build

### DIFF
--- a/.travis-requirements.txt
+++ b/.travis-requirements.txt
@@ -1,5 +1,5 @@
  setuptools
- sphinx>=2.0.0
+ sphinx==3.5.4
  PyEnchant>=1.6.5
  sphinxcontrib-spelling
  sphinx-intl


### PR DESCRIPTION
It seems early versions of Sphinx 4 are breaking extensions. Let's
stick with Sphinx 3 so far.

Related issue:
https://github.com/sphinx-contrib/plantuml/issues/56