### PR TITLE
Caption error in IPv6

### DIFF
--- a/protocols/ipv6.rst
+++ b/protocols/ipv6.rst
@@ -797,7 +797,7 @@ Routers regularly send Router Advertisement messages. These messages are trigger
 
 The last point that needs to be explained about ICMPv6 is the `Redirect` message. This message is used when there is more than one router on a subnet as shown in the figure below.
 
-   .. tikz:: A simple IPv6 network with one router
+   .. tikz:: A simple IPv6 network with two routers
       :libs: positioning, matrix, shapes
 
 


### PR DESCRIPTION
Changing the caption of the Fig.60 to "A simple IPv6 network with two routers"

Fix #80 