### PR TITLE
Fix: style of the navbar from interactive-syllabus

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,11 @@
+body > .container-xl {
+  transform: translate(0);
+}
+
+.navbar-syllabus {
+  line-height: 1.4;
+}
+
+.navbar-syllabus .dropdown {
+  position: unset;
+}

--- a/conf.py
+++ b/conf.py
@@ -166,6 +166,7 @@ html_logo = None
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ["custom.css"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
I have added a few line of css that override the css from the theme. Those lines aim to fix the styling for the navbar added by https://github.com/UCL-INGI/interactive-syllabus.

Before:
![image](https://user-images.githubusercontent.com/73463417/152580348-5724226a-e332-457a-944b-745de8f2ede7.png)

After:
![image](https://user-images.githubusercontent.com/73463417/152580393-44226281-f023-4e37-b8e9-61dacbf58a09.png)
