### PR TITLE
Add captions to sidebar

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -9,3 +9,7 @@ body > .container-xl {
 .navbar-syllabus .dropdown {
   position: unset;
 }
+
+.toctree-wrapper *:not(.figure) > .caption {
+  display: none;
+}

--- a/index.rst
+++ b/index.rst
@@ -43,6 +43,7 @@ Part 1: Principles
 
 .. toctree::
    :maxdepth: 4
+   :caption: Part 1: Principles
 
    principles/reliability
    principles/network
@@ -60,6 +61,7 @@ Part 2: Protocols
 
 .. toctree::
    :maxdepth: 4
+   :caption: Part 2: Protocols
 
    protocols/transport-service
    protocols/dns
@@ -88,6 +90,7 @@ Part 3: Practice
 
 .. toctree::
    :maxdepth: 4
+   :caption: Part 3: Practice
 
    exercises/intro
    exercises/reliability
@@ -165,6 +168,7 @@ Appendices
 
 .. toctree::
    :maxdepth: 4
+   :caption: Appendices
 
    glossary
    bibliography


### PR DESCRIPTION
This PR add captions to the sidebar to better distinguish different parts of the book. 

![image](https://user-images.githubusercontent.com/73463417/153608000-a7468363-a1b8-4b3d-80c0-7de632b27be8.png)

Drawback: In order to maintain the current style of headings in index.html and the structure of the sections in the pdf titles are duplicated.

```
##################
Part 1: Principles                      <---------------- HERE
##################

.. toctree::
   :maxdepth: 4
   :caption: Part 1: Principles         <---------------- HERE
```

Why adding a few lines of css ?
The duplication add the title twice in index.html as shown below.
![image](https://user-images.githubusercontent.com/73463417/153609359-7df86051-bae2-4cea-af04-1c611aa5f8de.png)
The css fix the issue for html, singlehtml and epub. Captions are not visible in pdf 
