### PR TITLE
Fix missing jquery lib

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,7 @@ import sys, os, shutil
 
 # add sphinx extensions
 sys.path.append(os.path.abspath("./util"))
-extensions = ['sphinx.ext.todo', 'sphinxcontrib.mscgen', 'sphinx.ext.graphviz', 'sphinxcontrib.tikz', 'sphinx.ext.mathjax', 'sphinxcontrib.spelling', 'interactive_syllabus_directives', 'matplotlib.sphinxext.plot_directive']
+extensions = ['sphinx.ext.todo', 'sphinxcontrib.mscgen', 'sphinx.ext.graphviz', 'sphinxcontrib.tikz', 'sphinx.ext.mathjax', 'sphinxcontrib.spelling', 'interactive_syllabus_directives', 'matplotlib.sphinxext.plot_directive', 'sphinxcontrib.jquery']
 
 
 #extensions = ['sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinxcontrib.mscgen','sphinx.ext.graphviz','sphinxcontrib.tikz','sphinxcontrib.spelling']

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ sphinxcontrib-spelling==8.0.1
 -e git+https://github.com/sphinx-contrib/tikz@a6ba7fad8bc2a3beec4da6144c0906ac344943ab#egg=sphinxcontrib_tikz
 typing_extensions==4.13.2
 urllib3==2.4.0
+sphinxcontrib-jquery==4.1


### PR DESCRIPTION
With recent version versions of sphinx, jquery is not included by default anymore, which triggered a display error for the INGInious exercises. Adding this sphinx extension fixes the issue.